### PR TITLE
Remove title name from type generation

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -344,7 +344,7 @@ function standaloneName(
   keyNameFromDefinition: string | undefined,
   usedNames: UsedNames,
 ): string | undefined {
-  const name = schema.title || schema.$id || keyNameFromDefinition
+  const name = schema.$id || keyNameFromDefinition
   if (name) {
     return generateName(name, usedNames)
   }


### PR DESCRIPTION
Removes the line that causes titles to form in that way